### PR TITLE
ByteStream.h: add a missing #include <cstdint>

### DIFF
--- a/libsoundtrackutil/include/libsoundtrackutil/ByteStream.h
+++ b/libsoundtrackutil/include/libsoundtrackutil/ByteStream.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include <gsl/span>
 #include <vector>
 

--- a/libsoundtrackutil/include/libsoundtrackutil/ByteStream.h
+++ b/libsoundtrackutil/include/libsoundtrackutil/ByteStream.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <gsl/span>
 #include <vector>
 


### PR DESCRIPTION
Fixes a compilation failure when building with aarch64-linux-gnu-g++-14.